### PR TITLE
ENG-3327 Remove hard coded rbnacl-libsodium gem dependency for packaged libsodium

### DIFF
--- a/cryptor.gemspec
+++ b/cryptor.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rbnacl-libsodium'
+  spec.add_development_dependency 'rbnacl'
 end

--- a/lib/cryptor/symmetric_encryption/ciphers/xsalsa20poly1305.rb
+++ b/lib/cryptor/symmetric_encryption/ciphers/xsalsa20poly1305.rb
@@ -1,4 +1,4 @@
-require 'rbnacl/libsodium'
+require 'rbnacl'
 
 require 'cryptor/symmetric_encryption/cipher'
 


### PR DESCRIPTION
We don't need to depend on `rbnacl-libsodium` which used to package `libsodium` within the gem. 